### PR TITLE
Always return promise, even if waitTime is zero

### DIFF
--- a/src/axios-retry-interceptor.js
+++ b/src/axios-retry-interceptor.js
@@ -54,13 +54,10 @@ const axiosRetryInterceptor = (axios, options = {}) => {
       error.config.__isRetryRequest = true;
       const waitTime = t(error.config.waitTime).isNumber ? error.config.waitTime : 0;
 
-      if (waitTime > 0) {
-        // eslint-disable-next-line no-unused-vars
-        return new Promise((resolve, reject) => {
-          setTimeout(() => resolve(axios(error.config)), waitTime);
-        });
-      }
-      return axios(error.config);
+      // eslint-disable-next-line no-unused-vars
+      return new Promise((resolve, reject) => {
+        setTimeout(() => resolve(axios(error.config)), waitTime);
+      });
     }
     return Promise.reject(error);
   });


### PR DESCRIPTION
For #1 this removes the conditional, such that for waitTime of 0, setTimeout pushes the callback function to the end of the execution queue. If after setTimeout(callback, 0) you have blocking code which takes time to run, the callback will not be executed until the blocking code has finished.

This allows different requests with zero waitTime retries to yield to one another between attempts, and simplifies the code.